### PR TITLE
Added driver parameter to get_connection_string and get_engine methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "py-pglite"
-version = "0.5.1"
+version = "0.5.2"
 description = "Python testing library for PGlite - in-memory PostgreSQL for tests"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/py_pglite/config.py
+++ b/src/py_pglite/config.py
@@ -8,6 +8,7 @@ import uuid
 from dataclasses import dataclass
 from dataclasses import field
 from pathlib import Path
+from typing import Literal
 
 from py_pglite.extensions import SUPPORTED_EXTENSIONS
 
@@ -86,11 +87,11 @@ class PGliteConfig:
         level_value = getattr(logging, self.log_level)
         return int(level_value)
 
-    def get_connection_string(self) -> str:
+    def get_connection_string(self, driver: Literal["psycopg", "psycopg2"] = "psycopg") -> str:
         """Get PostgreSQL connection string for SQLAlchemy usage."""
         if self.use_tcp:
             # TCP connection string
-            return f"postgresql+psycopg://postgres:postgres@{self.tcp_host}:{self.tcp_port}/postgres?sslmode=disable"
+            return f"postgresql+{driver}://postgres:postgres@{self.tcp_host}:{self.tcp_port}/postgres?sslmode=disable"
 
         # For SQLAlchemy with Unix domain sockets, we need to specify the directory
         # and use the standard PostgreSQL socket naming convention
@@ -98,7 +99,7 @@ class PGliteConfig:
 
         # Use the socket directory as host - psycopg will look for .s.PGSQL.5432
         connection_string = (
-            f"postgresql+psycopg://postgres:postgres@/postgres?host={socket_dir}"
+            f"postgresql+{driver}://postgres:postgres@/postgres?host={socket_dir}"
         )
 
         return connection_string

--- a/src/py_pglite/sqlalchemy/manager.py
+++ b/src/py_pglite/sqlalchemy/manager.py
@@ -5,7 +5,7 @@ Extends the core PGliteManager with SQLAlchemy-specific functionality.
 
 import time
 
-from typing import Any
+from typing import Any, Literal
 
 from py_pglite.manager import PGliteManager
 
@@ -22,7 +22,7 @@ class SQLAlchemyPGliteManager(PGliteManager):
         super().__enter__()
         return self
 
-    def get_engine(self, **engine_kwargs: Any) -> Any:
+    def get_engine(self, driver: Literal["psycopg", "psycopg2"] = "psycopg", **engine_kwargs: Any) -> Any:
         """Get SQLAlchemy engine connected to PGlite.
 
         NOTE: This method requires SQLAlchemy to be installed.
@@ -33,6 +33,7 @@ class SQLAlchemyPGliteManager(PGliteManager):
         architecture ensures all database operations use the same connection.
 
         Args:
+            driver: Which driver to use for connecting to the Postgres database. Defaults to 'psycopg'.
             **engine_kwargs: Additional arguments for create_engine
 
         Returns:
@@ -96,7 +97,7 @@ class SQLAlchemyPGliteManager(PGliteManager):
 
         # Create and store the shared engine
         self._shared_engine = create_engine(
-            self.config.get_connection_string(), **final_kwargs
+            self.config.get_connection_string(driver), **final_kwargs
         )
         return self._shared_engine
 


### PR DESCRIPTION
Legacy Python projects which use psycopg2 driver cannot currently use py-pglite, because the 
library does not support parametrizing the sqlalchemy connection string with driver name. 

This PR fixes this issue by allowing a driver name argument to be specified when calling the 
`get_connection_string` method of the `PGliteConfig` class and when calling the `get_engine` 
method of the `SQLAlchemyPGliteManager` class. 

The default value of this parameter is "psycopg", so this change is compatible with all existing 
usages of this library and does not break any implementations. Please consider merging this PR and 
releasing a new minor version, as my work on a legacy Python project depends on this change.

Here's some context of what I'm currently doing:
```python
def pytest_sessionstart(session: pytest.Session) -> None:
    pglite_config = PGliteConfig()

    # get_engine() does not support driver arg, so we use monkeypatch
    orig_conn_str = pglite_config.get_connection_string()
    patched_conn_str = orig_conn_str.replace("psycopg", "psycopg2")
    mp = pytest.MonkeyPatch()
    mp.setattr(
        target=pglite_config,
        name="get_connection_string",
        value=lambda: patched_conn_str,
    )
    pglite_manager = SQLAlchemyPGliteManager(config=pglite_config)
    pglite_manager.start()

    engine = pglite_manager.get_engine()

    script_loc = (TESTS_DIR.parent / 'migration_scripts').as_posix()
    alembic_cfg = AlembicConfig()
    alembic_cfg.set_main_option('script_location', script_loc)
    
    with engine.connect() as conn:
        alembic_cfg.attributes['connection'] = conn
        alembic_command.upgrade(alembic_cfg, 'head')
```
Instead of using MonkeyPatch to achieve the desired result, this PR would enable to use the following elegant solution:
```python
engine = pglite_manager.get_engine(driver="psycopg2")
```