### PR TITLE
Add data_dir as a config option

### DIFF
--- a/src/py_pglite/config.py
+++ b/src/py_pglite/config.py
@@ -32,6 +32,7 @@ class PGliteConfig:
         cleanup_on_exit: Whether to cleanup socket/process on exit (default: True)
         log_level: Logging level for PGlite operations (default: "INFO")
         socket_path: Custom socket path (default: secure temp directory)
+        data_dir: Where to persist pglite data (default: None, uses in memory database)
         work_dir: Working directory for PGlite files (default: None, uses temp)
         node_modules_check: Whether to verify node_modules exists (default: True)
         auto_install_deps: Whether to auto-install npm dependencies (default: True)
@@ -46,6 +47,7 @@ class PGliteConfig:
     cleanup_on_exit: bool = True
     log_level: str = "INFO"
     socket_path: str = field(default_factory=_get_secure_socket_path)
+    data_dir: Path | None = None
     work_dir: Path | None = None
     node_modules_check: bool = True
     auto_install_deps: bool = True
@@ -70,6 +72,9 @@ class PGliteConfig:
                         f"Unsupported extension: '{ext}'. "
                         f"Available extensions: {list(SUPPORTED_EXTENSIONS.keys())}"
                     )
+
+        if self.data_dir is not None:
+            self.data_dir = Path(self.data_dir).resolve()
 
         if self.work_dir is not None:
             self.work_dir = Path(self.work_dir).resolve()

--- a/src/py_pglite/manager.py
+++ b/src/py_pglite/manager.py
@@ -96,16 +96,19 @@ class PGliteManager:
 
             ext_requires_str = "\n".join(ext_requires)
             ext_configs_str = ",\n".join(ext_configs)
+            data_dir_str = json.dumps(
+                str(self.config.data_dir) if self.config.data_dir else None
+            )
             extensions_obj_str = f"{{\n{ext_configs_str}\n}}" if ext_configs else "{}"
 
             # Generate JavaScript content based on socket mode
             if self.config.use_tcp:
                 js_content = self._generate_tcp_js_content(
-                    ext_requires_str, extensions_obj_str
+                    ext_requires_str, extensions_obj_str, data_dir_str
                 )
             else:
                 js_content = self._generate_unix_js_content(
-                    ext_requires_str, extensions_obj_str
+                    ext_requires_str, extensions_obj_str, data_dir_str
                 )
             with open(manager_js, "w") as f:
                 f.write(js_content)
@@ -113,7 +116,7 @@ class PGliteManager:
         return work_dir
 
     def _generate_unix_js_content(
-        self, ext_requires_str: str, extensions_obj_str: str
+        self, ext_requires_str: str, extensions_obj_str: str, data_dir_str: str
     ) -> str:
         """Generate JavaScript content for Unix socket mode (original logic)."""
         return dedent(f"""
@@ -142,6 +145,7 @@ class PGliteManager:
                 try {{
                     // Create a PGlite instance with extensions
                     const db = new PGlite({{
+                        dataDir: {data_dir_str},
                         extensions: {extensions_obj_str}
                     }});
 
@@ -196,7 +200,7 @@ class PGliteManager:
         """).strip()
 
     def _generate_tcp_js_content(
-        self, ext_requires_str: str, extensions_obj_str: str
+        self, ext_requires_str: str, extensions_obj_str: str, data_dir_str: str
     ) -> str:
         """Generate JavaScript content for TCP socket mode."""
         return dedent(f"""
@@ -210,6 +214,7 @@ class PGliteManager:
                 try {{
                     // Create a PGlite instance with extensions
                     const db = new PGlite({{
+                        dataDir: {data_dir_str},
                         extensions: {extensions_obj_str}
                     }});
 

--- a/tests/test_config_comprehensive.py
+++ b/tests/test_config_comprehensive.py
@@ -83,6 +83,7 @@ class TestPGliteConfigValidationExtensive:
         assert config.timeout == 30
         assert config.cleanup_on_exit is True
         assert config.log_level == "INFO"
+        assert config.data_dir is None
         assert config.work_dir is None
         assert config.node_modules_check is True
         assert config.auto_install_deps is True
@@ -145,6 +146,24 @@ class TestPGliteConfigValidationExtensive:
         # Empty list should be fine
         config = PGliteConfig(extensions=[])
         assert config.extensions == []
+
+    def test_data_dir_path_resolution(self):
+        """Test data_dir path resolution and validation."""
+        # Relative path should be resolved to absolute
+        config = PGliteConfig(data_dir=Path("./test_dir"))
+        assert config.data_dir is not None
+        assert config.data_dir.is_absolute()
+
+        # Absolute path should be preserved
+        absolute_path = Path("/tmp/test_pglite").resolve()
+        config = PGliteConfig(data_dir=absolute_path)
+        assert config.data_dir is not None
+        assert config.data_dir == absolute_path
+
+        # Path object should work
+        config = PGliteConfig(data_dir=Path("./another_test"))
+        assert config.data_dir is not None
+        assert config.data_dir.is_absolute()
 
     def test_work_dir_path_resolution(self):
         """Test work_dir path resolution and validation."""
@@ -288,6 +307,7 @@ class TestPGliteConfigEdgeCases:
             cleanup_on_exit=False,
             log_level="ERROR",
             socket_path="/custom/path/.s.PGSQL.5432",
+            data_dir=Path("/custom/data"),
             work_dir=Path("/custom/work"),
             node_modules_check=False,
             auto_install_deps=False,
@@ -299,6 +319,8 @@ class TestPGliteConfigEdgeCases:
         assert config.cleanup_on_exit is False
         assert config.log_level == "ERROR"
         assert config.socket_path == "/custom/path/.s.PGSQL.5432"
+        assert config.data_dir is not None
+        assert config.data_dir == Path("/custom/data")
         assert config.work_dir is not None
         assert config.work_dir == Path("/custom/work")
         assert config.node_modules_check is False
@@ -384,6 +406,23 @@ class TestPGliteConfigValidationIntegration:
         with pytest.raises(ValueError):
             PGliteConfig(extensions=["invalid_extension"])
 
+    def test_data_dir_path_edge_cases(self):
+        """Test data_dir with various path formats."""
+        # Home directory expansion
+        config = PGliteConfig(data_dir=Path("~/test"))
+        assert config.data_dir is not None
+        assert config.data_dir.is_absolute()
+
+        # Current directory
+        config = PGliteConfig(data_dir=Path("."))
+        assert config.data_dir is not None
+        assert config.data_dir.is_absolute()
+
+        # Parent directory
+        config = PGliteConfig(data_dir=Path("../test"))
+        assert config.data_dir is not None
+        assert config.data_dir.is_absolute()
+
     def test_work_dir_path_edge_cases(self):
         """Test work_dir with various path formats."""
         # Home directory expansion
@@ -430,6 +469,28 @@ class TestPGliteConfigImports:
         config = PGliteConfig(log_level="DEBUG")
         # This should use the logging module to convert string to int
         assert config.log_level_int == logging.DEBUG
+
+
+class TestPGliteConfigDataDirEdgeCases:
+    """Test data_dir field edge cases."""
+
+    def test_data_dir_none_handling(self):
+        """Test that data_dir=None is handled correctly."""
+        config = PGliteConfig(data_dir=None)
+        assert config.data_dir is None
+
+    def test_data_dir_string_to_path_conversion(self):
+        """Test that string data_dir is converted to Path."""
+        config = PGliteConfig(data_dir=Path("/tmp/test"))
+        assert isinstance(config.data_dir, Path)
+        assert config.data_dir.is_absolute()
+
+    def test_data_dir_relative_path_resolution(self):
+        """Test that relative data_dir paths are resolved."""
+        config = PGliteConfig(data_dir=Path("./relative_path"))
+        assert config.data_dir is not None
+        assert config.data_dir.is_absolute()
+        assert "relative_path" in str(config.data_dir)
 
 
 class TestPGliteConfigWorkDirEdgeCases:


### PR DESCRIPTION
Enable persistent storage of the pglite db by exposing data_dir as a config option.